### PR TITLE
Added betting, event resolution, and winnings claim to Stacks Prediction Market

### DIFF
--- a/contracts/PredictStacks.clar
+++ b/contracts/PredictStacks.clar
@@ -73,3 +73,102 @@
   )
 )
 
+
+;; Place a bet on an event
+(define-public (place-bet (event-id uint) (option uint) (amount uint))
+  (let (
+    (event (unwrap! (map-get? events { event-id: event-id }) err-invalid-bet))
+    (current-time (unwrap-panic (get-block-info? time (- block-height u1))))
+  )
+    (asserts! (< current-time (get resolution-time event)) err-event-closed)
+    (asserts! (is-none (get winning-option event)) err-event-closed)
+    (asserts! (> amount u0) err-invalid-amount)
+    (asserts! (< option (len (get options event))) err-invalid-option)
+    (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+    (map-set bets { event-id: event-id, better: tx-sender } { amount: amount, option: option })
+    (map-set events { event-id: event-id }
+      (merge event { total-bets: (try! (add-safe (get total-bets event) amount)) })
+    )
+    (ok true)
+  )
+)
+
+;; Resolve an event
+(define-public (resolve-event (event-id uint) (winning-option uint))
+  (let ((event (unwrap! (map-get? events { event-id: event-id }) err-invalid-bet)))
+    (asserts! (is-eq tx-sender contract-owner) err-unauthorized)
+    (asserts! (is-none (get winning-option event)) err-event-closed)
+    (asserts! (>= (unwrap-panic (get-block-info? time (- block-height u1))) (get resolution-time event)) err-event-not-resolved)
+    (asserts! (< winning-option (len (get options event))) err-invalid-option)
+    (map-set events { event-id: event-id }
+      (merge event { 
+        is-resolved: true,
+        winning-option: (some winning-option)
+      })
+    )
+    (ok true)
+  )
+)
+
+;; Claim winnings
+(define-public (claim-winnings (event-id uint))
+  (let (
+    (event (unwrap! (map-get? events { event-id: event-id }) err-invalid-bet))
+    (bet (unwrap! (map-get? bets { event-id: event-id, better: tx-sender }) err-invalid-bet))
+    (winning-option (unwrap! (get winning-option event) err-event-not-resolved))
+  )
+    (asserts! (is-eq (get option bet) winning-option) err-invalid-bet)
+    (let (
+      (total-bets (get total-bets event))
+      (option-bets (get-total-bets-for-option event-id winning-option))
+    )
+      (asserts! (> option-bets u0) err-invalid-bet)
+      (let (
+        (winning-amount (/ (* (get amount bet) total-bets) option-bets))
+      )
+        (try! (as-contract (stx-transfer? winning-amount tx-sender tx-sender)))
+        (map-delete bets { event-id: event-id, better: tx-sender })
+        (ok winning-amount)
+      )
+    )
+  )
+)
+
+(define-private (get-bet-amount-for-option (bet { amount: uint, option: uint }) (target-option uint))
+  (if (is-eq (get option bet) target-option)
+    (get amount bet)
+    u0
+  )
+)
+
+
+;; Get total bets for a specific option
+(define-private (get-total-bets-for-option (event-id uint) (option uint))
+  (let ((bets-for-event (map-get? bets { event-id: event-id, better: tx-sender })))
+    (match bets-for-event
+      bet (if (is-eq (get option bet) option)
+              (get amount bet)
+              u0)
+      u0)
+  )
+)
+
+;; Safe addition to prevent overflow
+(define-private (add-safe (a uint) (b uint))
+  (let ((sum (+ a b)))
+    (asserts! (>= sum a) err-overflow)
+    (ok sum)
+  )
+)
+
+;; Read-only functions
+
+;; Get event details
+(define-read-only (get-event (event-id uint))
+  (map-get? events { event-id: event-id })
+)
+
+;; Get bet details
+(define-read-only (get-bet (event-id uint) (better principal))
+  (map-get? bets { event-id: event-id, better: better })
+)


### PR DESCRIPTION
### Pull Request Description  

**Title:** Implement Betting, Event Resolution, and Winnings Claim for Stacks Prediction Market  

**Description:**  
This PR introduces core functionalities for the Stacks Prediction Market smart contract, allowing users to place bets, resolve events, and claim winnings. It ensures security, fairness, and transparency while handling bets and payouts. Key additions include:  

- **Bet Placement (`place-bet`)**: Users can bet on events before resolution time. The contract verifies bet validity, ensures event openness, and transfers the bet amount to the contract.  
- **Event Resolution (`resolve-event`)**: The contract owner can finalize events by declaring a winning option once the resolution time has passed.  
- **Winnings Claim (`claim-winnings`)**: Users who correctly predicted the event outcome can claim their winnings. The payout is calculated based on total bets and winning bets for the event.  
- **Helper Functions**:  
  - `get-total-bets-for-option`: Computes total bets placed on a given option.  
  - `add-safe`: Ensures safe addition, preventing overflow errors.  
- **Read-Only Queries**: Users can retrieve event and bet details via `get-event` and `get-bet`.  

**Security Considerations:**  
- Users cannot place bets on closed or resolved events.  
- Only the contract owner can resolve events.  
- Overflow errors are prevented using `add-safe`.  
- Winnings are only claimable for correct bets.  
